### PR TITLE
Updated epaddr to use references with lifetimes instead of Rc.

### DIFF
--- a/ep/src/lib.rs
+++ b/ep/src/lib.rs
@@ -62,7 +62,7 @@ pub struct Epaddr <'a> {
 
 
 impl Ep {
-  // TODO: change job_key to rust uuid, add psm_ep
+  // TODO: change job_key to rust uuid, add psm_ep, add new
   pub fn open<'a>(job_key: u64, ep_opts: EpOpts) -> Result<(Ep, &'a Epaddr<'a>), Error> {
     Err(Error { error: Error_type::PSM_ERROR_LAST, error_str: "send help"})
   }
@@ -72,13 +72,12 @@ impl Ep {
   }
 
   pub fn connect<'a>(ep: Ep, epids: Box<Vec<Epid>>, epid_masks: &Vec<isize>, timeout: i64) -> Result<Box<Vec<&'a Epaddr<'a>>>, Box<Vec<Error>>> {
-    let dummy: Vec<Error> = Vec::new();
-    Err(Box::new(dummy))
+    Err(Box::new(vec!()))
   }
 }
 
 impl <'a>Epaddr <'a> {
-
+  // TODO: figure out what fields are commonly used when epaddr is constructed
 }
 /* TODO: see if we can make this into a struct so we can real getters/setters that dont have the
  * words get/set

--- a/ep/src/lib.rs
+++ b/ep/src/lib.rs
@@ -50,6 +50,9 @@ pub struct Epaddr <'a> {
   mctxt_nsconn: usize,
   mctxt_send_seqnum: u16,
   mctxt_recv_seqnum: u16,
+  /* TODO: consider http://rustbyexample.com/enum.html to make this a linked list,
+   * depending on how the C version works.
+   */
   mctxt_current: Option<&'a Epaddr<'a>>,
   // outoforder_q: Mqsq TODO: make Mqsq type
   outoforder_c: usize,

--- a/ep/src/lib.rs
+++ b/ep/src/lib.rs
@@ -3,8 +3,11 @@ extern crate error;
 use error::{Error_type,Error};
 use std::rc::Rc;
 use self::consts::*;
+use self::macros::*;
 
 pub mod consts;
+#[macro_use]
+pub mod macros;
 
 // TODO: determine more appropriate types instead of passing -1/NULL, psm.h:449
 // TODO: when rust supports conditional compilation add PSM_VERNO conditional fields
@@ -33,7 +36,7 @@ enum PtlAddr {
   ptladdr_data ([u8; 0])
 }
 
-pub struct Epaddr {
+pub struct Epaddr <'a> {
   // *ptl: ptl          TODO: ptl is a reference to the parent obj
   //ptlctrl: Ptl_ctl,
   epid: Epid,
@@ -47,21 +50,20 @@ pub struct Epaddr {
   mctxt_nsconn: usize,
   mctxt_send_seqnum: u16,
   mctxt_recv_seqnum: u16,
-  mctxt_current: Option<Rc<Epaddr>>,
+  mctxt_current: Option<&'a Epaddr<'a>>,
   // outoforder_q: Mqsq TODO: make Mqsq type
   outoforder_c: usize,
 
   // Linked list of Epaddr for multi-context
-  // TODO: what type of pointers? box, raw, Rc?
-  mctxt_master: Option<Rc<Epaddr>>,
-  mctxt_prev: Option<Rc<Epaddr>>,
-  mctxt_next: Option<Rc<Epaddr>>
+  mctxt_master: Option<&'a Epaddr<'a>>,
+  mctxt_prev: Option<&'a Epaddr<'a>>,
+  mctxt_next: Option<&'a Epaddr<'a>>
 }
 
 
 impl Ep {
   // TODO: change job_key to rust uuid, add psm_ep
-  pub fn open(job_key: u64, ep_opts: EpOpts) -> Result<Box<(Ep, Epaddr)>, Error> {
+  pub fn open<'a>(job_key: u64, ep_opts: EpOpts) -> Result<(Ep, &'a Epaddr<'a>), Error> {
     Err(Error { error: Error_type::PSM_ERROR_LAST, error_str: "send help"})
   }
 
@@ -69,13 +71,13 @@ impl Ep {
     Ok(())
   }
 
-  pub fn connect(ep: Ep, epids: &Vec<Epid>, epid_masks: &Vec<isize>, timeout: i64) -> Result<Box<Vec<Epaddr>>, Box<Vec<Error>>> {
+  pub fn connect<'a>(ep: Ep, epids: Box<Vec<Epid>>, epid_masks: &Vec<isize>, timeout: i64) -> Result<Box<Vec<&'a Epaddr<'a>>>, Box<Vec<Error>>> {
     let dummy: Vec<Error> = Vec::new();
     Err(Box::new(dummy))
   }
 }
 
-impl Epaddr {
+impl <'a>Epaddr <'a> {
 
 }
 /* TODO: see if we can make this into a struct so we can real getters/setters that dont have the

--- a/ep/src/macros.rs
+++ b/ep/src/macros.rs
@@ -1,0 +1,8 @@
+macro_rules! pack_epid {
+  ($lid:expr, $ctxt:expr, $sub_ctxt:expr, $hca_type:expr, $sl:expr) => (
+    ((($lid as u64) & 0xffff) << 16) |
+    ((($sub_ctxt as u64) & 0x3) << 14) |
+    ((($ctxt as u64) & 0x3f) << 8) |
+    ((($sl as u64) & 0x4) << 4) |
+    (($hca_type as u64) & 0xf));
+}

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -47,8 +47,7 @@ pub struct Error {
 
 impl Error {
   pub fn new(error: Error_type, error_str: &'static str)
-    -> Error {
-      Error { error: error, error_str: error_str }
+    -> Error { Error { error: error, error_str: error_str }
   }
 
   pub fn error_type_to_string(self) -> &'static str {

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -46,6 +46,11 @@ pub struct Error {
 }
 
 impl Error {
+  pub fn new(error: Error_type, error_str: &'static str)
+    -> Error {
+      Error { error: error, error_str: error_str }
+  }
+
   pub fn error_type_to_string(self) -> &'static str {
     "NONE()"
   }


### PR DESCRIPTION
Using macros in defined in other files/mods/crates is a bit weird in rust atm.
The macro i added is not often, it was more of a test to see if i could namespace macros in thier own file.

@acmcarther
