### PR TITLE
Fixing Error constructor.

### DIFF
--- a/ep/src/lib.rs
+++ b/ep/src/lib.rs
@@ -66,7 +66,7 @@ pub struct Epaddr <'a> {
 impl Ep {
   // TODO: change job_key to rust uuid, add psm_ep, add new
   pub fn open<'a>(job_key: u64, ep_opts: EpOpts) -> Result<(Ep, &'a Epaddr<'a>), Error> {
-    Err(Error { error: ErrorType::PSM_ERROR_LAST, error_str: "send help"})
+    Err(Error::new(ErrorType::PSM_ERROR_LAST, "send help"))
   }
 
   pub fn close(ep: Ep, mode: isize, timeout: u64) -> Result<(), Error> {

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -47,7 +47,7 @@ pub struct Error {
 
 impl Error {
   pub fn new(error: ErrorType, error_str: &'static str) -> Error {
-    Error::new(error, error_str)
+    Error { error: error, error_str: error_str }
   }
 
   pub fn error_type_to_string(self) -> &'static str {


### PR DESCRIPTION
Add new() in correct place.
Interesting rustc didn't error on a recursive constructor.
Might have been a warning.

I still need to gitgud.

@acmcarther
