### PR TITLE
Add context open fn and supporting mods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ env:
     - LD_LIBRARY_PATH: /usr/local/lib
 script:
   - cargo build
+  - cargo test

--- a/src/ep/mod.rs
+++ b/src/ep/mod.rs
@@ -1,3 +1,5 @@
+//! Datatypes and functions related to Ep (endpoints) aka psm_ep_t,
+//! (for now) EpAddr aka psm_epaddr_t, and Epid aka psm_epid_t.
 extern crate uuid;
 
 use error::Error;

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -1,3 +1,9 @@
+//! Provides an easier way to access the linux driver error functions
+//! such as errno and strerror. This module is needed because many C functions
+//! set serrno in the case of failures. Since PSM needs to use the /dev/ipath
+//! character file, errno gets set anytime the ib_qib driver encounters a
+//! problem.
+
 #![macro_use]
 
 extern crate libc;
@@ -23,7 +29,7 @@ macro_rules! dump_errno_str {
 }
 
 #[test]
-/// Forcing EISDIR by setting O_WRONLY on /tmp
+// Forcing EISDIR by setting O_WRONLY on /tmp
 fn errno_e_is_dir() {
   let fd = open("/tmp", libc::O_WRONLY);
   assert_eq!(errno(), libc::EISDIR);

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -1,0 +1,24 @@
+extern crate libc;
+use std::ffi::CString;
+use std::os::raw::c_char;
+use libc::c_int;
+use fileops::open;
+
+pub fn strerrer(errno: c_int) -> String {
+  unsafe {
+    let c_err_str = libc::strerror(errno);
+    CString::from_raw(c_err_str).into_string()
+      .unwrap_or(String::from("Unknown errno"))
+  }
+}
+
+pub fn errno() -> c_int {
+  unsafe { *libc::__errno_location() }
+}
+
+#[test]
+/// Forcing EISDIR by setting O_WRONLY on /tmp
+fn errno_eisdir() {
+  let fd = open("/tmp", libc::O_WRONLY);
+  assert_eq!(errno(), libc::EISDIR);
+}

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -24,8 +24,12 @@ pub fn errno() -> c_int {
   unsafe { *libc::__errno_location() }
 }
 
+#[macro_export]
 macro_rules! dump_errno_str {
-  () => (format!("errno: {}, errno str {}", errno(), strerror(errno())))
+  () => {{
+    use $crate::errno;
+    format!("errno: {}, errno str {}", errno(), strerror(errno()))
+  }}
 }
 
 #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+//! Contains the different error codes that were in psm.h in the C version.
 pub enum Error {
     Ok,
     NoProgress,

--- a/src/fileops.rs
+++ b/src/fileops.rs
@@ -13,6 +13,7 @@ pub fn close(fd: c_int) -> c_int {
 }
 
 #[test]
+// Check open/close on a file that should exist in most linux based OS.
 fn open_close_devnull() -> () {
   let fd = open("/dev/null", libc::O_RDONLY);
   assert!(fd >= 0);

--- a/src/fileops.rs
+++ b/src/fileops.rs
@@ -1,0 +1,21 @@
+extern crate libc;
+
+use std::ffi::CString;
+use libc::c_int;
+
+pub fn open<T: Into<String>>(path: T, mode: c_int) -> c_int {
+  unsafe { libc::open(CString::new(path.into())
+                      .unwrap_or(CString::new("").unwrap()).as_ptr(), mode) }
+}
+
+pub fn close(fd: c_int) -> c_int {
+  unsafe { libc::close(fd) }
+}
+
+#[test]
+fn open_close_devnull() -> () {
+  let fd = open("/dev/null", libc::O_RDONLY);
+  assert!(fd >= 0);
+  let ret = close(fd);
+  assert!(ret != -1);
+}

--- a/src/fileops.rs
+++ b/src/fileops.rs
@@ -1,3 +1,8 @@
+//! Contains operations related to the /dev/ipath character files.
+//! fcntl is not included because rust does not allow for the C-style
+//! argument list (...) outside of ffi functions. fcntl is only used once
+//! in the C version.
+
 extern crate libc;
 
 use std::ffi::CString;

--- a/src/ipath/mod.rs
+++ b/src/ipath/mod.rs
@@ -1,0 +1,1 @@
+pub mod service;

--- a/src/ipath/mod.rs
+++ b/src/ipath/mod.rs
@@ -1,1 +1,4 @@
+//! This module should be equivalent to the ipath directory in the C version.
+//! Mostly support functions and functions to interface with the ib_qib driver
+//! will live in this module.
 pub mod service;

--- a/src/ipath/service.rs
+++ b/src/ipath/service.rs
@@ -3,38 +3,38 @@ extern crate libc;
 use std::os::unix::io::RawFd;
 use std::ffi::CString;
 use fileops::{open, close};
-use errno::{errno, strerrer};
+use errno::*;
 
 fn ipath_context_open(unit: isize) -> Option<libc::c_int> {
-  let dev_path = match unit {
-    u if unit >= 0 => format!("/dev/ipath{}", u),
-    _ => format!("/dev/ipath")
+  let dev_path = if unit >= 0 {
+    format!("/dev/ipath{}", unit)
+  } else {
+    format!("/dev/ipath")
   };
 
+  // open and fcntl return -1 and set errno in the case of an error
+  // the fd here is the result, but we need to check fcntl's result
   let fd = open(dev_path, libc::O_RDWR);
-
-  match fd {
-    -1 => None,
-    _ => unsafe {
-      match libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) {
-        -1 => None,
-        _ => Some(fd)
-      }
-    }
+  // We can get away w/o checking open, because fcntl on fd -1 does nothing
+  if unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) } >= 0 {
+    Some(fd)
+  } else {
+    None
   }
 }
 
 #[test]
+// ignored because /dev/ipath to be created by ib_qib, travis doesn't have
+// the proper hardware to do tests based on the driver.
 #[ignore]
-/// Requires /dev/ipath to be created by ib_qib, ignore for travis
 // TODO: add a test for checking all available units
 fn open_close_unit_zero() {
   let fd_maybe = ipath_context_open(0);
   match fd_maybe {
-    None => panic!("errno: {}, errno str {}", errno(), strerrer(errno())),
+    None => panic!(dump_errno_str!()),
     Some(fd) => {
       match close(fd) {
-        -1 => panic!("errno: {}, errno str {}", errno(), strerrer(errno())),
+        -1 => panic!(dump_errno_str!()),
         _ => ()
       }
     }

--- a/src/ipath/service.rs
+++ b/src/ipath/service.rs
@@ -1,0 +1,42 @@
+extern crate libc;
+
+use std::os::unix::io::RawFd;
+use std::ffi::CString;
+use fileops::{open, close};
+use errno::{errno, strerrer};
+
+fn ipath_context_open(unit: isize) -> Option<libc::c_int> {
+  let dev_path = match unit {
+    u if unit >= 0 => format!("/dev/ipath{}", u),
+    _ => format!("/dev/ipath")
+  };
+
+  let fd = open(dev_path, libc::O_RDWR);
+
+  match fd {
+    -1 => None,
+    _ => unsafe {
+      match libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) {
+        -1 => None,
+        _ => Some(fd)
+      }
+    }
+  }
+}
+
+#[test]
+#[ignore]
+/// Requires /dev/ipath to be created by ib_qib, ignore for travis
+// TODO: add a test for checking all available units
+fn open_close_unit_zero() {
+  let fd_maybe = ipath_context_open(0);
+  match fd_maybe {
+    None => panic!("errno: {}, errno str {}", errno(), strerrer(errno())),
+    Some(fd) => {
+      match close(fd) {
+        -1 => panic!("errno: {}, errno str {}", errno(), strerrer(errno())),
+        _ => ()
+      }
+    }
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ extern crate libc;
 extern crate uuid;
 
 pub mod error;
+pub mod errno;
+pub mod fileops;
 pub mod ep;
 pub mod ipath;
 pub mod ptl_am;

--- a/src/ptl_am/mod.rs
+++ b/src/ptl_am/mod.rs
@@ -1,0 +1,2 @@
+//! ptl_am - Packet Transport Layer for Active Messages and for shared memory
+//! messages.

--- a/src/ptl_ips/mod.rs
+++ b/src/ptl_ips/mod.rs
@@ -1,0 +1,1 @@
+//! ptl_ips - Packet Transport Layer for the Interconnect Protocol Stack.

--- a/src/ptl_self/mod.rs
+++ b/src/ptl_self/mod.rs
@@ -1,0 +1,1 @@
+//! ptl_self - Packet Transport Layer for loop-back/send-to-self


### PR DESCRIPTION
Fileops contains open and close wrappers from libc. fnctl is not needed
in this mod as it is already a simple function and needs no type casts
or special tricks. Also, rust does not have support for the ... argument
list outside of the ffi mod.

Errno contains errno and strerror, errno is not provded by libc. errno
fn in the Errno mod provides the error number like with C errno().
libc::__errno_location is used to access the error number.

The file descriptor of a /dev/ipath device can now  be obtained using
ipath_context_open.

cargo test was added to the .travis.yml, however tests that require /dev/ipath to exist will have the #[ignore] attribute so that travis can do tests without correct infiniband hardware.
