### PR TITLE
Add Fd struct

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -12,7 +12,7 @@ use std::ffi::CString;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use libc::c_int;
-use fileops::open;
+use fileops::Fd;
 
 pub fn strerror(errno: c_int) -> String {
   unsafe {
@@ -35,7 +35,7 @@ macro_rules! dump_errno_str {
 #[test]
 // Forcing EISDIR by setting O_WRONLY on /tmp
 fn errno_e_is_dir() {
-  let fd = open("/tmp", libc::O_WRONLY);
+  let fd = Fd::open("/tmp", libc::O_WRONLY);
   assert_eq!(errno(), libc::EISDIR);
   assert_eq!(strerror(errno()), "Is a directory");
 }

--- a/src/fileops.rs
+++ b/src/fileops.rs
@@ -1,7 +1,4 @@
 //! Contains operations related to the /dev/ipath character files.
-//! fcntl is not included because rust does not allow for the C-style
-//! argument list (...) outside of ffi functions. fcntl is only used once
-//! in the C version.
 
 extern crate libc;
 
@@ -26,9 +23,8 @@ impl Fd {
     unsafe { libc::close(self.0) }
   }
 
-  pub fn fcntl(&self, cmd: c_int, arg: c_int ) -> Option<c_int> {
-    let ret = unsafe { libc::fcntl(self.0, cmd, arg) };
-    match ret {
+  pub fn try_set_flag(&self, flag: c_int ) -> Option<c_int> {
+    match unsafe { libc::fcntl(self.0, libc::F_SETFD, flag) } {
       -1 => None,
       _ => Some(0)
     }

--- a/src/fileops.rs
+++ b/src/fileops.rs
@@ -22,8 +22,16 @@ impl Fd {
     }
   }
 
-  fn close(&mut self) -> c_int {
+  fn close(&self) -> c_int {
     unsafe { libc::close(self.0) }
+  }
+
+  pub fn fcntl(&self, cmd: c_int, arg: c_int ) -> Option<c_int> {
+    let ret = unsafe { libc::fcntl(self.0, cmd, arg) };
+    match ret {
+      -1 => None,
+      _ => Some(0)
+    }
   }
 }
 

--- a/src/ipath/service.rs
+++ b/src/ipath/service.rs
@@ -19,12 +19,10 @@ fn ipath_context_open(unit: isize) -> Option<Fd> {
   let fd_maybe = Fd::open(dev_path, libc::O_RDWR);
   match fd_maybe {
     Some(fd) => {
-      unsafe {
-        if libc::fcntl(fd.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC) >= 0 {
-          Some(fd)
-        } else {
-          None
-        }
+      if fd.fcntl(libc::F_SETFD, libc::FD_CLOEXEC).is_some() {
+        Some(fd)
+      } else {
+        None
       }
     },
     None => None

--- a/src/ipath/service.rs
+++ b/src/ipath/service.rs
@@ -14,19 +14,17 @@ fn ipath_context_open(unit: isize) -> Option<Fd> {
 
   // XXX: Do we need ipath_wait_for_device? it literally just waits.
 
-  // open and fcntl return -1 and set errno in the case of an error
-  // the fd here is the result, but we need to check fcntl's result
+  // Try to get a Fd and try to set the CLOEXEC flag on it.
   let fd_maybe = Fd::open(dev_path, libc::O_RDWR);
   match fd_maybe {
-    Some(fd) => {
-      if fd.fcntl(libc::F_SETFD, libc::FD_CLOEXEC).is_some() {
-        Some(fd)
-      } else {
-        None
+    Some(ref fd) => {
+      if fd.try_set_flag(libc::FD_CLOEXEC).is_none() {
+        println!("{}", dump_errno_str!());
       }
     },
-    None => None
+    _ => ()
   }
+  fd_maybe
 }
 
 #[test]

--- a/src/ipath/service.rs
+++ b/src/ipath/service.rs
@@ -1,25 +1,33 @@
 extern crate libc;
 
-use std::os::unix::io::RawFd;
 use std::ffi::CString;
-use fileops::{open, close};
+use fileops::Fd;
 use errno::*;
+use std::os::unix::io::AsRawFd;
 
-fn ipath_context_open(unit: isize) -> Option<libc::c_int> {
+fn ipath_context_open(unit: isize) -> Option<Fd> {
   let dev_path = if unit >= 0 {
     format!("/dev/ipath{}", unit)
   } else {
     format!("/dev/ipath")
   };
 
+  // XXX: Do we need ipath_wait_for_device? it literally just waits.
+
   // open and fcntl return -1 and set errno in the case of an error
   // the fd here is the result, but we need to check fcntl's result
-  let fd = open(dev_path, libc::O_RDWR);
-  // We can get away w/o checking open, because fcntl on fd -1 does nothing
-  if unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) } >= 0 {
-    Some(fd)
-  } else {
-    None
+  let fd_maybe = Fd::open(dev_path, libc::O_RDWR);
+  match fd_maybe {
+    Some(fd) => {
+      unsafe {
+        if libc::fcntl(fd.as_raw_fd(), libc::F_SETFD, libc::FD_CLOEXEC) >= 0 {
+          Some(fd)
+        } else {
+          None
+        }
+      }
+    },
+    None => None
   }
 }
 
@@ -30,13 +38,7 @@ fn ipath_context_open(unit: isize) -> Option<libc::c_int> {
 // TODO: add a test for checking all available units
 fn open_close_unit_zero() {
   let fd_maybe = ipath_context_open(0);
-  match fd_maybe {
-    None => panic!(dump_errno_str!()),
-    Some(fd) => {
-      match close(fd) {
-        -1 => panic!(dump_errno_str!()),
-        _ => ()
-      }
-    }
+  if fd_maybe.is_none() {
+    panic!(dump_errno_str!());
   }
 }


### PR DESCRIPTION
Add Fd struct to wrap usage of RawFd/c_int for file descriptors. Allows for usage of functions like open/close on an object rather than just a raw number we get from libc.
