### PR TITLE
Add sysfs mod for port/unit attribute reads, fix unused imports

### DIFF
--- a/src/ep/mod.rs
+++ b/src/ep/mod.rs
@@ -4,7 +4,6 @@ extern crate uuid;
 
 use error::Error;
 use self::consts::*;
-use self::macros::*;
 use uuid::Uuid;
 
 pub mod consts;

--- a/src/fileops.rs
+++ b/src/fileops.rs
@@ -7,7 +7,6 @@ use libc::c_int;
 use std::os::unix::io::{RawFd, AsRawFd};
 use std::ops::Drop;
 use std::io::Error;
-use std::error::Error as std_error;
 
 pub struct Fd(RawFd);
 
@@ -51,7 +50,8 @@ impl Drop for Fd {
 
 #[test]
 // Check open/close on a file that should exist in most linux based OS.
-fn open_close_devnull() -> () {
+fn open_close_devnull() {
+  use std::error::Error as std_error;
   match Fd::open("/dev/null", libc::O_RDONLY) {
     Err(e) => panic!(e.description().to_owned()),
     _ => ()

--- a/src/ipath/mod.rs
+++ b/src/ipath/mod.rs
@@ -2,3 +2,4 @@
 //! Mostly support functions and functions to interface with the ib_qib driver
 //! will live in this module.
 pub mod service;
+pub mod sysfs;

--- a/src/ipath/service.rs
+++ b/src/ipath/service.rs
@@ -1,9 +1,7 @@
 extern crate libc;
 
-use std::ffi::CString;
 use fileops::Fd;
 use std::io::Error;
-use std::error::Error as std_error;
 
 fn ipath_context_open(unit: isize) -> Result<Fd, Error> {
   let dev_path = if unit >= 0 {
@@ -26,6 +24,7 @@ fn ipath_context_open(unit: isize) -> Result<Fd, Error> {
 #[ignore]
 // TODO: add a test for checking all available units
 fn open_close_unit_zero() {
+  use std::error::Error as std_error;
   match ipath_context_open(0) {
     Err(e) => panic!(e.description().to_owned()),
     _ => ()

--- a/src/ipath/sysfs.rs
+++ b/src/ipath/sysfs.rs
@@ -1,0 +1,58 @@
+//! Allows for reading of ib_qib attributes from sysfs files.
+//! Examples include number of free contexts and InfiniBand GIDS.
+
+use std::io::{Error, Read};
+use std::fs::File;
+
+static SYSFS_PATH: &'static str = "/sys/class/infiniband/qib";
+
+/// Reads attributes from /sys/class/infiniband/qib[0-9]/ports/[0-1]/*
+pub fn read_port_attr(unit: u32, port: u32,
+                      attr: &'static str) -> Result<String, Error> {
+  let path = format!("{}{}/ports/{}/{}", SYSFS_PATH, unit, port, attr);
+  let mut f = try!(File::open(path));
+  let mut port_val = String::new();
+  try!(f.read_to_string(&mut port_val));
+  Ok(port_val.replace("\n",""))
+}
+
+/// Reads attributes from /sys/class/infiniband/qib[0-9]/*
+pub fn read_unit_attr(unit: u32, attr: &'static str)-> Result<String, Error> {
+  let path = format!("{}{}/{}", SYSFS_PATH, unit, attr);
+  let mut f = try!(File::open(path));
+  let mut unit_val = String::new();
+  try!(f.read_to_string(&mut unit_val));
+  Ok(unit_val.replace("\n",""))
+}
+
+// Testing file: /sys/class/infiniband/qib0/hca_type
+#[test]
+// Requires: ib_qib to be loaded with a valid adapter
+#[ignore]
+fn check_unit_hca_type() {
+  use std::error::Error as std_error;
+  match read_unit_attr(0, "hca_type") {
+    Ok(hca_type) => {
+      if !hca_type.contains("InfiniPath_QLE") {
+        panic!("Got invalid hca type {}, expected InfiniPath_QLE*", hca_type);
+      }
+    },
+    Err(e) => panic!(e.description().to_owned())
+  }
+}
+
+// Testing file: /sys/class/infiniband/qib0/ports/1/link_layer
+#[test]
+// Requires: ib_qib to be loaded with a valid adapter
+#[ignore]
+fn check_port_link_layer() {
+  use std::error::Error as std_error;
+  match read_port_attr(0, 1, "link_layer") {
+    Ok(link_layer) => {
+      if link_layer != "InfiniBand" {
+        panic!("Got invalid link_layer {}, expected InfiniBand", link_layer);
+      }
+    },
+    Err(e) => panic!(e.description().to_owned())
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@ pub mod ptl_ips;
 pub mod ptl_self;
 
 use error::Error;
-use ep::*;
-use std::result;
 
 pub struct Version {
   major: usize,


### PR DESCRIPTION
ipath::sysfs::\* added to support reads of driver attributes found in
/sys/class/infiniband/qib*, the C lib does support writes to these files
but those functions are not used.
